### PR TITLE
Minor fix on the timeout

### DIFF
--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditorIdlingTracker.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditorIdlingTracker.js
@@ -92,7 +92,7 @@ qx.Class.define("osparc.desktop.StudyEditorIdlingTracker", {
         const flashMessageDurationS = Math.round(inactivityThresholdT * 0.2);
         this.__idlingTime++;
 
-        if (this.__idlingTime >= inactivityThresholdT && !this.__idleFlashMessageIsShowing) {
+        if (this.__idlingTime >= (inactivityThresholdT-flashMessageDurationS) && !this.__idleFlashMessageIsShowing) {
           const timeSinceInactivityThreshold = this.__idlingTime - inactivityThresholdT;
           if (timeSinceInactivityThreshold % this.self().INACTIVITY_REQUEST_PERIOD_S == 0) {
             // check if backend reports project as inactive

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditorIdlingTracker.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditorIdlingTracker.js
@@ -46,7 +46,7 @@ qx.Class.define("osparc.desktop.StudyEditorIdlingTracker", {
       }
 
       let msg = qx.locale.Manager.tr("Are you still there?") + "<br>";
-      msg += qx.locale.Manager.tr("If not, oSPARC will close the ") + osparc.product.Utils.getStudyAlias() + qx.locale.Manager.tr(" in: ");
+      msg += `If not, ${osparc.store.StaticInfo.getInstance().getDisplayName()} will try to close the ${osparc.product.Utils.getStudyAlias()} in:`;
       msg += osparc.utils.Utils.formatSeconds(timeoutSec);
       this.__idleFlashMessage.setMessage(msg);
     },

--- a/services/static-webserver/client/source/class/osparc/utils/WebWorkerScheduler.js
+++ b/services/static-webserver/client/source/class/osparc/utils/WebWorkerScheduler.js
@@ -20,7 +20,7 @@
   */
 
 /**
- * Singleton class to be used as a dorp-in replacement for`setInterval` and `clearInterval`.
+ * Singleton class to be used as a drop-in replacement for`setInterval` and `clearInterval`.
  * Depending on browser and OS, `setInterval` might not be called if the  window is
  * not visible on the screen.
  */


### PR DESCRIPTION
## What do these changes do?

We were actually waiting for 1.2 times inactivityThresholdT. This PR fixes it.

A nice way to test it (not sure how you did it for when the window is minimized...) is to add the following in the ``checkFn`` in the ``startTimer`` method:

``document.title = `${this.__idlingTime}s idling`;``

I couldn't test it properly with running services. Let's have a look on Monday.


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
